### PR TITLE
Add Process Execution Simulation to Test Harness

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1339,10 +1339,8 @@ class ExecProcess(Generic[AnyStr]):
         else:
             out = io.BytesIO()
             err = io.BytesIO() if self.stderr is not None else None
-        # self.stdout can be None, when exec is invoked with the stdout argument
-        if self.stdout is not None:
-            t = _start_thread(shutil.copyfileobj, self.stdout, out)
-            self._threads.append(t)
+        t = _start_thread(shutil.copyfileobj, self.stdout, out)
+        self._threads.append(t)
 
         if self.stderr is not None:
             t = _start_thread(shutil.copyfileobj, self.stderr, err)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1322,7 +1322,7 @@ class ExecProcess(Generic[AnyStr]):
             exit_code = change.tasks[0].data.get('exit-code', -1)
         return exit_code
 
-    def wait_output(self) -> Tuple[Optional[AnyStr], Optional[AnyStr]]:
+    def wait_output(self) -> Tuple[AnyStr, Optional[AnyStr]]:
         """Wait for the process to finish and return tuple of (stdout, stderr).
 
         If a timeout was specified to the :meth:`Client.exec` call, this waits
@@ -1350,7 +1350,7 @@ class ExecProcess(Generic[AnyStr]):
 
         exit_code: int = self._wait()
 
-        out_value = typing.cast(AnyStr, out.getvalue()) if out is not None else None
+        out_value = typing.cast(AnyStr, out.getvalue())
         err_value = typing.cast(AnyStr, err.getvalue()) if err is not None else None
         if exit_code != 0:
             raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1339,6 +1339,7 @@ class ExecProcess(Generic[AnyStr]):
         else:
             out = io.BytesIO()
             err = io.BytesIO() if self.stderr is not None else None
+
         t = _start_thread(shutil.copyfileobj, self.stdout, out)
         self._threads.append(t)
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1632,11 +1632,11 @@ class Harness(Generic[CharmType]):
             harness.handle_exec('container', [], result=0)
 
             # simple example that just produces output (exit code 0)
-            harness.handle_exec('webserver', ['ls', '/etc'], result='passwdprofile')
+            harness.handle_exec('webserver', ['ls', '/etc'], result='passwd\nprofile\n')
 
             # slightly more complex (use stdin)
             harness.handle_exec('c1', ['sha1sum'],
-                                handler=lambda args: hashlib.sha1(args.stdin).hexdigest())
+                                handler=lambda args: ExecResult(stdout=hashlib.sha1(args.stdin).hexdigest()))
 
             # more complex example using args.command
             def docker_handler(args: testing.ExecArgs) -> testing.ExecResult:
@@ -2896,7 +2896,7 @@ class _TestingPebbleClient:
                 return io.StringIO(data.decode(encoding=encoding))
         else:
             if encoding is None:
-                raise ValueError("exec handler return str while bytes is required")
+                raise ValueError(f"exec handler must return bytes if encoding is None, not {data.__class__.__name__}")
             else:
                 return io.StringIO(data)
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -111,10 +111,10 @@ CharmType = TypeVar('CharmType', bound=charm.CharmBase)
 
 @dataclasses.dataclass
 class ExecArgs:
-    """Represent arguments captured from the :meth:`ops.model.Container.exec` method call.
+    """Represent arguments captured from the :meth:`ops.Container.exec` method call.
 
-    These arguments will be passed to the :class:`ops.testing.ExecHandler` handler function.
-    See :meth:`ops.model.Container.exec` for documentation of properties.
+    These arguments will be passed to the ``ops.testing.ExecHandler`` handler function.
+    See :meth:`ops.Container.exec` for documentation of properties.
     """
     command: List[str]
     environment: Dict[str, str]
@@ -134,7 +134,7 @@ class ExecResult:
     """Represents the result of a simulated process execution.
 
     This class is typically used to return the output and exit code from the
-    :class:`ops.testing.ExecHandler` handler function.
+    ``ops.testing.ExecHandler`` handler function.
     """
     exit_code: int = 0
     stdout: Union[str, bytes] = b""
@@ -1591,7 +1591,7 @@ class Harness(Generic[CharmType]):
         """Register a handler to simulate the pebble command execution.
 
         This allows a test harness to simulate the behavior of running commands in a container.
-        When :meth:`ops.model.Container.exec` is triggered, the registered handler is used to
+        When :meth:`ops.Container.exec` is triggered, the registered handler is used to
         simulate the process execution.
 
         You can provide:
@@ -1613,7 +1613,7 @@ class Harness(Generic[CharmType]):
         The execution handler receives the timeout value in ExecArgs. If needed, it can raise a
         TimeoutError to inform the harness of a timeout occurrence.
 
-        If :meth:`ops.model.Container.exec` is called with ``combine_stderr=True``, the execution
+        If :meth:`ops.Container.exec` is called with ``combine_stderr=True``, the execution
         handler should, if required, weave the simulated standard error into the standard output.
         The harness checks the result and will raise an exception if stderr is non-empty.
 
@@ -2878,7 +2878,6 @@ class _TestingPebbleClient:
             file_path.unlink()
 
     def _find_exec_handler(self, command: List[str]) -> Optional[ExecHandler]:
-        print(self._exec_handlers)
         for command_prefix, handler in self._exec_handlers:
             if tuple(command[:len(command_prefix)]) == command_prefix:
                 return handler

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1598,10 +1598,8 @@ class Harness(Generic[CharmType]):
         You can provide either a ``handler`` or a ``result``, but not both:
 
         - A ``handler``: A function accepting :class:`ops.testing.ExecArgs` and returning
-          :class:`ops.testing.ExecResult` as the simulated process outcome. For simpler cases, the
-          handler can return a string (or byte string)
-          (equivalent to ``ExecResult(exit_code=0, stdout=str_or_bytes)``) or an integer
-          (equivalent to ``ExecResult(exit_code=return_value)``).
+          :class:`ops.testing.ExecResult` as the simulated process outcome. For pure side effect
+          cases, the handler can return None (equivalent to ``ExecResult()``).
 
         - A ``result``: For simulations that don't need to inspect the ``exec`` arguments, the
           output and exit code can be returned directly. Setting ``result`` to str or bytes means

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -113,7 +113,7 @@ CharmType = TypeVar('CharmType', bound=charm.CharmBase)
 class ExecArgs:
     """Represent arguments captured from the :meth:`ops.Container.exec` method call.
 
-    These arguments will be passed to the ``ops.testing.ExecHandler`` handler function.
+    These arguments will be passed to the :meth:`Harness.handle_exec` handler function.
     See :meth:`ops.Container.exec` for documentation of properties.
     """
     command: List[str]

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2503,12 +2503,19 @@ class _TestingPebbleClient:
 
     def _handle_exec(self, command_prefix: List[str], handler: ExecHandler):
         prefix = tuple(command_prefix)
-        for idx, registered_handler in enumerate(self._exec_handlers):
+        inserted = False
+        for idx in range(len(self._exec_handlers)):
+            if inserted:
+                idx = idx + 1
+            registered_handler = self._exec_handlers[idx]
             if prefix == registered_handler[0]:
                 self._exec_handlers[idx] = (prefix, handler)
                 return
-        self._exec_handlers.append((prefix, handler))
-        self._exec_handlers.sort(key=lambda pair: len(pair[0]), reverse=True)
+            if not inserted and len(prefix) > len(registered_handler[0]):
+                self._exec_handlers.insert(idx, (prefix, handler))
+                inserted = True
+        if not inserted:
+            self._exec_handlers.append((prefix, handler))
 
     def _check_connection(self):
         if not self._backend._can_connect(self):
@@ -2871,6 +2878,7 @@ class _TestingPebbleClient:
             file_path.unlink()
 
     def _find_exec_handler(self, command: List[str]) -> Optional[ExecHandler]:
+        print(self._exec_handlers)
         for command_prefix, handler in self._exec_handlers:
             if tuple(command[:len(command_prefix)]) == command_prefix:
                 return handler

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1660,15 +1660,15 @@ class Harness(Generic[CharmType]):
         if (handler is None and result is None) or (handler is not None and result is not None):
             raise TypeError("Either handler or result must be provided, but not both.")
         container_name = container if isinstance(container, str) else container.name
-        if result is None:
-            pass
-        elif isinstance(result, int) and not isinstance(result, bool):
-            result = ExecResult(exit_code=result)
-        elif isinstance(result, (str, bytes)):
-            result = ExecResult(stdout=result)
-        elif not isinstance(result, ExecResult):
-            raise TypeError(
-                f"result must be int, str, bytes, or ExecResult, not {result.__class__.__name__}")
+        if result is not None:
+            if isinstance(result, int) and not isinstance(result, bool):
+                result = ExecResult(exit_code=result)
+            elif isinstance(result, (str, bytes)):
+                result = ExecResult(stdout=result)
+            elif not isinstance(result, ExecResult):
+                raise TypeError(
+                    f"result must be int, str, bytes, or ExecResult, "
+                    f"not {result.__class__.__name__}")
         self._backend._pebble_clients[container_name]._handle_exec(
             command_prefix=command_prefix,
             handler=(lambda _: result) if handler is None else handler  # type: ignore
@@ -2885,6 +2885,7 @@ class _TestingPebbleClient:
             command_prefix = tuple(command[:prefix_len])
             if command_prefix in self._exec_handlers:
                 return self._exec_handlers[command_prefix]
+        return None
 
     def _transform_exec_handler_output(self,
                                        data: Union[str, bytes],

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -15,7 +15,6 @@
 """Infrastructure to build unit tests for charms using the ops library."""
 
 
-import bisect
 import dataclasses
 import datetime
 import fnmatch
@@ -2508,9 +2507,8 @@ class _TestingPebbleClient:
             if prefix == registered_handler[0]:
                 self._exec_handlers[idx] = (prefix, handler)
                 return
-        bisect.insort(self._exec_handlers,
-                      (prefix, handler),
-                      key=lambda pair: len(pair[0]))  # type: ignore
+        self._exec_handlers.append((prefix, handler))
+        self._exec_handlers.sort(key=lambda pair: len(pair[0]), reverse=True)
 
     def _check_connection(self):
         if not self._backend._can_connect(self):
@@ -2873,7 +2871,7 @@ class _TestingPebbleClient:
             file_path.unlink()
 
     def _find_exec_handler(self, command: List[str]) -> Optional[ExecHandler]:
-        for command_prefix, handler in reversed(self._exec_handlers):
+        for command_prefix, handler in self._exec_handlers:
             if tuple(command[:len(command_prefix)]) == command_prefix:
                 return handler
         return None

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1608,7 +1608,8 @@ class Harness(Generic[CharmType]):
           that exit code (and no stdout).
           to setting ``handler=lambda _: result``.
 
-        In cases of multiple command line argument prefix matches for a single command, the
+        If ``handle_exec`` is called more than once with overlapping command prefixes,
+        the longest match takes precedence.
         longest match takes precedence. The execution handler registration can be updated by
         re-registering with the same command prefix.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1628,7 +1628,7 @@ class Harness(Generic[CharmType]):
 
         Example usage::
 
-            # handle every command
+            # produce no output and return 0 for every command
             harness.handle_exec('container', [], result=0)
 
             # simple example that just produces output (exit code 0)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1602,7 +1602,7 @@ class Harness(Generic[CharmType]):
           (equivalent to ``ExecResult(exit_code=0, stdout=str_or_bytes)``) or an integer
           (equivalent to ``ExecResult(exit_code=return_value)``).
 
-        - A ``result``: For simulations don't need to inspect the execution argument, the
+        - A ``result``: For simulations that don't need to inspect the ``exec`` arguments, the
           registration can be further simplified using the ``result`` argument. This is equivalent
           to setting ``handler=lambda _: result``.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1625,11 +1625,12 @@ class Harness(Generic[CharmType]):
             result: A simplified form to specify the command's simulated result.
 
         Example usage::
+
             # handle every command
             harness.handle_exec('container', [], result=0)
 
             # simple example that just produces output (exit code 0)
-            harness.handle_exec('webserver', ['ls', '/etc'], result='passwd\nprofile\n')
+            harness.handle_exec('webserver', ['ls', '/etc'], result='passwdprofile')
 
             # slightly more complex (use stdin)
             harness.handle_exec('c1', ['sha1sum'],
@@ -1641,7 +1642,7 @@ class Harness(Generic[CharmType]):
                     case ['docker', 'run', image]:
                         return testing.ExecResult(stdout=f'running {image}')
                     case ['docker', 'ps']:
-                        return testing.ExecResult(stdout='CONTAINER ID   IMAGE ...\n')
+                        return testing.ExecResult(stdout='CONTAINER ID   IMAGE ...')
                     case _:
                         return testing.ExecResult(exit_code=1, stderr='unknown command')
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -114,7 +114,7 @@ class ExecArgs:
     """Represent arguments captured from the :meth:`ops.Container.exec` method call.
 
     These arguments will be passed to the :meth:`Harness.handle_exec` handler function.
-    See :meth:`ops.Container.exec` for documentation of properties.
+    See :meth:`ops.pebble.Client.exec` for documentation of properties.
     """
     command: List[str]
     environment: Dict[str, str]

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2474,7 +2474,7 @@ class _TestingExecProcess:
     def wait(self):
         if self._is_timeout:
             raise pebble.TimeoutError(
-                f'timed out waiting for change 123 ({self._timeout} seconds)'
+                f'timed out waiting for change ({self._timeout} seconds)'
             )
         if self._exit_code != 0:
             raise pebble.ExecError(self._command, cast(int, self._exit_code), None, None)
@@ -2482,7 +2482,7 @@ class _TestingExecProcess:
     def wait_output(self) -> Tuple[AnyStr, Optional[AnyStr]]:
         if self._is_timeout:
             raise pebble.TimeoutError(
-                f'timed out waiting for change 123 ({self._timeout} seconds)'
+                f'timed out waiting for change ({self._timeout} seconds)'
             )
         out_value = self.stdout.read() if self.stdout is not None else None
         err_value = self.stderr.read() if self.stderr is not None else None

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1594,7 +1594,7 @@ class Harness(Generic[CharmType]):
         When :meth:`ops.Container.exec` is triggered, the registered handler is used to
         generate stdout and stderr for the simulated execution.
 
-        You can provide:
+        You can provide either a ``handler`` or a ``result``, but not both:
 
         - A ``handler``: A function accepting :class:`ops.testing.ExecArgs` and returning
           :class:`ops.testing.ExecResult` as the simulated process outcome. For simpler cases, the

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1622,7 +1622,7 @@ class Harness(Generic[CharmType]):
 
         Args:
             container: The specified container or its name.
-            command_prefix: The command prefixes to register against.
+            command_prefix: The command prefix to register against.
             handler: A handler function that simulates the command's execution.
             result: A simplified form to specify the command's simulated result.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1588,7 +1588,7 @@ class Harness(Generic[CharmType]):
                     *,
                     handler: Optional[ExecHandler] = None,
                     result: Optional[Union[int, str, bytes, ExecResult]] = None):
-        """Register a handler to simulate the pebble command execution.
+        """Register a handler to simulate the Pebble command execution.
 
         This allows a test harness to simulate the behavior of running commands in a container.
         When :meth:`ops.Container.exec` is triggered, the registered handler is used to

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1603,7 +1603,9 @@ class Harness(Generic[CharmType]):
           (equivalent to ``ExecResult(exit_code=return_value)``).
 
         - A ``result``: For simulations that don't need to inspect the ``exec`` arguments, the
-          registration can be further simplified using the ``result`` argument. This is equivalent
+          output and exit code can be returned directly. Setting ``result`` to str or bytes means
+          use that string as stdout (with exit code 0), or setting ``result`` to int means return
+          that exit code (and no stdout).
           to setting ``handler=lambda _: result``.
 
         In cases of multiple command line argument prefix matches for a single command, the

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -134,7 +134,7 @@ class ExecResult:
     """Represents the result of a simulated process execution.
 
     This class is typically used to return the output and exit code from the
-    ``ops.testing.ExecHandler`` handler function.
+    :meth:`Harness.handle_exec` result or handler function.
     """
     exit_code: int = 0
     stdout: Union[str, bytes] = b""

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1592,7 +1592,7 @@ class Harness(Generic[CharmType]):
 
         This allows a test harness to simulate the behavior of running commands in a container.
         When :meth:`ops.Container.exec` is triggered, the registered handler is used to
-        simulate the process execution.
+        generate stdout and stderr for the simulated execution.
 
         You can provide:
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1597,23 +1597,22 @@ class Harness(Generic[CharmType]):
 
         You can provide either a ``handler`` or a ``result``, but not both:
 
-        - A ``handler``: A function accepting :class:`ops.testing.ExecArgs` and returning
-          :class:`ops.testing.ExecResult` as the simulated process outcome. For pure side effect
-          cases, the handler can return None (equivalent to ``ExecResult()``).
+        - A ``handler`` is a function accepting :class:`ops.testing.ExecArgs` and returning
+          :class:`ops.testing.ExecResult` as the simulated process outcome. For cases that
+          have side effects but don't return output, the handler can return ``None``, which
+          is equivalent to returning ``ExecResult()``.
 
-        - A ``result``: For simulations that don't need to inspect the ``exec`` arguments, the
-          output and exit code can be returned directly. Setting ``result`` to str or bytes means
-          use that string as stdout (with exit code 0), or setting ``result`` to int means return
+        - A ``result`` is for simulations that don't need to inspect the ``exec`` arguments; the
+          output or exit code is provided directly. Setting ``result`` to str or bytes means
+          use that string as stdout (with exit code 0); setting ``result`` to int means return
           that exit code (and no stdout).
-          to setting ``handler=lambda _: result``.
 
-        If ``handle_exec`` is called more than once with overlapping command prefixes,
-        the longest match takes precedence.
-        longest match takes precedence. The execution handler registration can be updated by
+        If ``handle_exec`` is called more than once with overlapping command prefixes, the
+        longest match takes precedence. The registration of an execution handler can be updated by
         re-registering with the same command prefix.
 
-        The execution handler receives the timeout value in ExecArgs. If needed, it can raise a
-        TimeoutError to inform the harness of a timeout occurrence.
+        The execution handler receives the timeout value in the ``ExecArgs``. If needed,
+        it can raise a ``TimeoutError`` to inform the harness that a timeout occurred.
 
         If :meth:`ops.Container.exec` is called with ``combine_stderr=True``, the execution
         handler should, if required, weave the simulated standard error into the standard output.
@@ -1651,8 +1650,8 @@ class Harness(Generic[CharmType]):
             harness.handle_exec('database', ['docker'], handler=docker_handler)
 
             # handle timeout
-            def handle_timeout(exec_args: testing.ExecArgs) -> int:
-                if exec_args.timeout is not None and exec_args.timeout < 10:
+            def handle_timeout(args: testing.ExecArgs) -> int:
+                if args.timeout is not None and args.timeout < 10:
                     raise TimeoutError
                 return 0
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -19,7 +19,6 @@ import importlib
 import inspect
 import io
 import ipaddress
-import itertools
 import os
 import pathlib
 import platform
@@ -5086,19 +5085,3 @@ class TestHandleExec(unittest.TestCase):
         self.assertEqual(args_history[-1].group, "test_group")
         self.assertEqual(args_history[-1].group_id, 4)
         self.assertDictEqual(args_history[-1].environment, {"foo": "hello", "foobar": "barfoo"})
-
-    def test_registration_order(self):
-        for n in range(7):
-            pebble = self.harness._backend._pebble_clients[self.container.name]
-            for prefix_lengths in itertools.product(range(1, n + 1), repeat=n):
-                pebble._exec_handlers = []
-                for idx, prefix_len in enumerate(prefix_lengths):
-                    self.harness.handle_exec(self.container, [str(idx)] * prefix_len, result=0)
-                handlers = pebble._exec_handlers
-                self.assertTrue(all(
-                    len(handlers[i][0]) >= len(handlers[i + 1][0])
-                    for i in range(len(handlers) - 1)))
-                self.assertEqual(len(handlers), len(prefix_lengths))
-                for idx, handler in enumerate(handlers):
-                    self.harness.handle_exec(self.container, handler[0], result=idx)
-                    self.assertEqual(handlers[idx][1](None).exit_code, idx)


### PR DESCRIPTION
The Pebble process execution plays an important role in a lot of charms. However, the ops framework testing module currently lacks built-in functionality to simulate this process, leading many charms to roll their own patching and mocking mechanisms for unit tests.

To address this problem, this pull request introduces `ops.testing.Harness.handle_exec`, a new feature that enables the simulation of Pebble process execution within the Ops framework testing module.

Also a fix is implemented for a null safety issue in `ops.pebble.ExecProcess.wait_output`. This is a breaking change and could potentially trigger static check failures in charms.
